### PR TITLE
Fix ACLGroup item sorting

### DIFF
--- a/routes/aclgroup.js
+++ b/routes/aclgroup.js
@@ -55,7 +55,7 @@ app.get('/aclgroup', async (req, res) => {
             .limit(50)
             .lean();
 
-        if(query.rev?.$gte) revs.reverse();
+        if(query.id?.$gte) groupItems.reverse();
     }
 
     let prevItem;


### PR DESCRIPTION
## Summary
- correct query check when fetching ACL group items
- reverse fetched group items when requesting newer IDs

## Testing
- `npm test` *(fails: cross-env not found)*